### PR TITLE
Use libcgal_jll v0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 julia = "1.3"
-libcgal_julia_jll = "0.17"
-CxxWrap = "0.11"
+libcgal_julia_jll = "0.18"
+CxxWrap = "0.12"
 Requires = "1"
 
 [extras]


### PR DESCRIPTION
`@wrapmodule` seems to fail. @barche is that an issue from the C++ wrapper or do I need to add something on the Julia side ?
```julia
julia> using CGAL
[ Info: Precompiling CGAL [15fcbb24-5a00-427b-98c5-e32879a22884]
C++ exception while wrapping module CGAL: No appropriate factory for type N4CGAL15Triangulation_3INS_5EpickENS_30Triangulation_data_structure_3INS_27Triangulation_vertex_base_3IS1_NS_30Triangulation_ds_vertex_base_3IvEEEENS_34Delaunay_triangulation_cell_base_3IS1_NS_25Triangulation_cell_base_3IS1_NS_28Triangulation_ds_cell_base_3IvEEEEEENS_14Sequential_tagEEENS_7DefaultEEE
ERROR: LoadError: No appropriate factory for type N4CGAL15Triangulation_3INS_5EpickENS_30Triangulation_data_structure_3INS_27Triangulation_vertex_base_3IS1_NS_30Triangulation_ds_vertex_base_3IvEEEENS_34Delaunay_triangulation_cell_base_3IS1_NS_25Triangulation_cell_base_3IS1_NS_28Triangulation_ds_cell_base_3IvEEEEEENS_14Sequential_tagEEENS_7DefaultEEE
Stacktrace:
 [1] register_julia_module
   @ C:\Users\blegat\.julia\packages\CxxWrap\IdOJa\src\CxxWrap.jl:405 [inlined]
 [2] readmodule(so_path::String, funcname::Symbol, m::Module, flags::Nothing)
   @ CxxWrap.CxxWrapCore C:\Users\blegat\.julia\packages\CxxWrap\IdOJa\src\CxxWrap.jl:734
 [3] wrapmodule(so_path::String, funcname::Symbol, m::Module, flags::Nothing)
   @ CxxWrap.CxxWrapCore C:\Users\blegat\.julia\packages\CxxWrap\IdOJa\src\CxxWrap.jl:738
 [4] include
   @ .\Base.jl:419 [inlined]
 [5] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt64}}, source::Nothing)
   @ Base .\loading.jl:1554
in expression starting at C:\Users\blegat\.julia\dev\CGAL\src\CGAL.jl:1
in expression starting at stdin:1
ERROR: Failed to precompile CGAL [15fcbb24-5a00-427b-98c5-e32879a22884] to C:\Users\blegat\.julia\compiled\v1.8\CGAL\jl_1B64.tmp.
Stacktrace:
l.jl:222
 [12] (::VSCodeServer.var"#107#109"{Module, Expr, REPL.LineEditREPL, REPL.LineEdit.Prompt})()
    @ VSCodeServer c:\Users\blegat\.vscode\extensions\julialang.language-julia-1.7.12\scripts\packages\VSCodeServer\src\repl.jl:186
 [13] with_logstate(f::Function, logstate::Any)
    @ Base.CoreLogging .\logging.jl:511
 [14] with_logger
    @ .\logging.jl:623 [inlined]
 [15] (::VSCodeServer.var"#106#108"{Module, Expr, REPL.LineEditREPL, REPL.LineEdit.Prompt})()
    @ VSCodeServer c:\Users\blegat\.vscode\extensions\julialang.language-julia-1.7.12\scripts\packages\VSCodeServer\src\repl.jl:187
 [16] #invokelatest#2
    @ .\essentials.jl:729 [inlined]
 [17] invokelatest(::Any)
    @ Base .\essentials.jl:726
 [18] macro expansion
    @ c:\Users\blegat\.vscode\extensions\julialang.language-julia-1.7.12\scripts\packages\VSCodeServer\src\eval.jl:34 [inlined]
 [19] (::VSCodeServer.var"#61#62")()
    @ VSCodeServer .\task.jl:484

julia> using CGAL
[ Info: Precompiling CGAL [15fcbb24-5a00-427b-98c5-e32879a22884]
CxxWrap.CxxWrapCore.wrapmodule(get(ENV, "JLCGAL_LIBPATH", libcgal_julia()), :define_julia_module, CGAL, nothing)
ERROR: LoadError: UndefVarError: AffTransformation2 not defined
Stacktrace:
 [1] top-level scope
   @ C:\Users\blegat\.julia\dev\CGAL\src\kernel.jl:78
 [2] include(mod::Module, _path::String)
   @ Base .\Base.jl:419
 [3] include(x::String)
 [11] repleval(m::Module, code::Expr, #unused#::String)
    @ VSCodeServer c:\Users\blegat\.vscode\extensions\julialang.language-julia-1.7.12\scripts\packages\VSCodeServer\src\repl.jl:222
 [12] (::VSCodeServer.var"#107#109"{Module, Expr, REPL.LineEditREPL, REPL.LineEdit.Prompt})()
    @ VSCodeServer c:\Users\blegat\.vscode\extensions\julialang.language-julia-1.7.12\scripts\packages\VSCodeServer\src\repl.jl:186 [13] with_logstate(f::Function, logstate::Any)
    @ Base.CoreLogging .\logging.jl:511
 [14] with_logger
    @ .\logging.jl:623 [inlined]
 [15] (::VSCodeServer.var"#106#108"{Module, Expr, REPL.LineEditREPL, REPL.LineEdit.Prompt})()
    @ VSCodeServer c:\Users\blegat\.vscode\extensions\julialang.language-julia-1.7.12\scripts\packages\VSCodeServer\src\repl.jl:187
 [16] #invokelatest#2    @ .\essentials.jl:729 [inlined]
 [17] invokelatest(::Any)
    @ Base .\essentials.jl:726
 [18] macro expansion    @ c:\Users\blegat\.vscode\extensions\julialang.language-julia-1.7.12\scripts\packages\VSCodeServer\src\eval.jl:34 [inlined]
 [19] (::VSCodeServer.var"#61#62")()    @ VSCodeServer .\task.jl:484
```