### PR TITLE
Add libcgal_julia v0.18 compat and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 [compat]
 julia = "1.3"
 libcgal_julia_jll = "0.17, 0.18"
-CxxWrap = "0.11"
+CxxWrap = "0.14"
 Requires = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CGAL"
 uuid = "15fcbb24-5a00-427b-98c5-e32879a22884"
 authors = ["Rui Ventura <rventura.pt@outlook.com>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 libcgal_julia_jll = "e9ad47b2-a301-5fb7-a0bd-6eece649b37c"
@@ -10,7 +10,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 julia = "1.3"
-libcgal_julia_jll = "0.17"
+libcgal_julia_jll = "0.17, 0.18"
 CxxWrap = "0.11"
 Requires = "1"
 


### PR DESCRIPTION
This is causing issues when trying to use the latest CGAL.jl version on Mac M-series platforms.